### PR TITLE
[Bug Fix] Fix missing city and postal code to the email

### DIFF
--- a/emails/OrderConfirmationTemplate.tsx
+++ b/emails/OrderConfirmationTemplate.tsx
@@ -109,26 +109,26 @@ export default async function OrderConfirmationTemplate(customerInfo: CustomerIn
                   <Text style={informationTableValue}>{customerInfo.shippingBuilding}</Text>
                   <Text style={informationTableValue}>{customerInfo.shippingAddress}</Text>
                   <Text style={informationTableValue}>
-                    {customerInfo.useSameAddress ? t('address_shipping_and_invoice') : t('address_shipping')}
+                    {[customerInfo.shippingCity, customerInfo.shippingPostalCode].join(' - ')}
                   </Text>
                   <Text style={informationTableValue}>
-                    {[customerInfo.invoiceProvince, customerInfo.invoiceCountry].filter(x => x).join(' - ')}
+                    {[customerInfo.shippingProvince, customerInfo.shippingCountry].filter(x => x).join(' - ')}
                   </Text>
                 </Row>
                 { !customerInfo.useSameAddress &&
-<Row>
-  <Text style={informationTableLabel}>
-    {t('address_invoice')}
-  </Text>
-  <Text style={informationTableValue}>{customerInfo.invoiceBuilding}</Text>
-  <Text style={informationTableValue}>{customerInfo.invoiceAddress}</Text>
-  <Text style={informationTableValue}>
-    {customerInfo.useSameAddress ? t('address_shipping_and_invoice') : t('address_shipping')}
-  </Text>
-  <Text style={informationTableValue}>
-    {[customerInfo.invoiceProvince, customerInfo.invoiceCountry].filter(x => x).join(' - ')}
-  </Text>
-</Row>
+                  <Row>
+                    <Text style={informationTableLabel}>
+                      {t('address_invoice')}
+                    </Text>
+                    <Text style={informationTableValue}>{customerInfo.invoiceBuilding}</Text>
+                    <Text style={informationTableValue}>{customerInfo.invoiceAddress}</Text>
+                    <Text style={informationTableValue}>
+                      {[customerInfo.invoiceCity, customerInfo.invoicePostalCode].join(' - ')}
+                    </Text>
+                    <Text style={informationTableValue}>
+                      {[customerInfo.invoiceProvince, customerInfo.invoiceCountry].filter(x => x).join(' - ')}
+                    </Text>
+                  </Row>
                 }
               </Column>
             </Row>


### PR DESCRIPTION
# What changed?

Issue: missing city and the postal code in the email template (both invoice and shipping addresses):

![image](https://github.com/malparty/avuedecoucou-store/assets/77609814/8c0577c5-bbcb-40f3-aad2-11b074bb6071)


# Proof of work

![image](https://github.com/malparty/avuedecoucou-store/assets/77609814/1aecd94c-d39d-4047-999f-eeb820880a3a)
